### PR TITLE
[Feature]: Add title input after selecting a course

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -104,6 +104,7 @@ class QuizCreate(SQLModel):
     canvas_course_id: int
     canvas_course_name: str
     selected_modules: dict[int, str]
+    title: str = Field(min_length=1)
 
 
 class UserPublic(SQLModel):

--- a/frontend/src/components/QuizCreation/CourseSelectionStep.tsx
+++ b/frontend/src/components/QuizCreation/CourseSelectionStep.tsx
@@ -3,28 +3,34 @@ import {
   Box,
   Card,
   HStack,
+  Input,
   RadioGroup,
   Skeleton,
   Text,
   VStack,
-} from "@chakra-ui/react"
-import { useQuery } from "@tanstack/react-query"
+} from "@chakra-ui/react";
+import { useQuery } from "@tanstack/react-query";
 
-import { CanvasService } from "@/client"
+import { CanvasService } from "@/client";
+import { Field } from "@/components/ui/field";
 
 interface Course {
-  id: number
-  name: string
+  id: number;
+  name: string;
 }
 
 interface CourseSelectionStepProps {
-  selectedCourse?: Course
-  onCourseSelect: (course: Course) => void
+  selectedCourse?: Course;
+  onCourseSelect: (course: Course) => void;
+  title?: string;
+  onTitleChange: (title: string) => void;
 }
 
 export function CourseSelectionStep({
   selectedCourse,
   onCourseSelect,
+  title,
+  onTitleChange,
 }: CourseSelectionStepProps) {
   const {
     data: courses,
@@ -36,7 +42,7 @@ export function CourseSelectionStep({
     retry: 1, // Only retry once instead of default 3 times
     retryDelay: 1000, // Wait 1 second between retries
     staleTime: 30000, // Consider data stale after 30 seconds
-  })
+  });
 
   if (isLoading) {
     return (
@@ -48,7 +54,7 @@ export function CourseSelectionStep({
           <Skeleton key={i} height="60px" borderRadius="md" />
         ))}
       </VStack>
-    )
+    );
   }
 
   if (error) {
@@ -61,7 +67,7 @@ export function CourseSelectionStep({
           check your Canvas connection.
         </Alert.Description>
       </Alert.Root>
-    )
+    );
   }
 
   if (!courses || courses.length === 0) {
@@ -74,7 +80,7 @@ export function CourseSelectionStep({
           check your Canvas account or contact your administrator.
         </Alert.Description>
       </Alert.Root>
-    )
+    );
   }
 
   return (
@@ -84,8 +90,11 @@ export function CourseSelectionStep({
           Select a course to create a quiz for
         </Text>
         <Text color="gray.600" fontSize="sm">
+          Here is the courses we found where you have a teacher role.
+        </Text>
+        <Text color="gray.600" fontSize="sm">
           Choose the course where you want to generate quiz questions from the
-          course materials.
+          module materials.
         </Text>
       </Box>
 
@@ -102,7 +111,7 @@ export function CourseSelectionStep({
               }
               bg={selectedCourse?.id === course.id ? "blue.50" : "white"}
               onClick={() => {
-                onCourseSelect(course)
+                onCourseSelect(course);
               }}
               data-testid={`course-card-${course.id}`}
             >
@@ -127,13 +136,30 @@ export function CourseSelectionStep({
       </RadioGroup.Root>
 
       {selectedCourse && (
-        <Alert.Root status="success">
-          <Alert.Indicator />
-          <Alert.Description>
-            Selected: <strong>{selectedCourse.name}</strong>
-          </Alert.Description>
-        </Alert.Root>
+        <VStack gap={4} align="stretch">
+          <Alert.Root status="success">
+            <Alert.Indicator />
+            <Alert.Description>
+              Selected: <strong>{selectedCourse.name}</strong>
+            </Alert.Description>
+          </Alert.Root>
+
+          <Box>
+            <Field label="Quiz Title" required>
+              <Input
+                value={title || ""}
+                onChange={(e) => onTitleChange(e.target.value)}
+                placeholder="Enter quiz title"
+                data-testid="quiz-title-input"
+              />
+            </Field>
+            <Text fontSize="sm" color="gray.600" mt={1}>
+              This is the quiz title shown in Canvas and when browsing quizzes.
+              You can modify it before continuing.
+            </Text>
+          </Box>
+        </VStack>
       )}
     </VStack>
-  )
+  );
 }

--- a/frontend/src/routes/_layout/create-quiz.tsx
+++ b/frontend/src/routes/_layout/create-quiz.tsx
@@ -24,6 +24,7 @@ interface QuizFormData {
     name: string
   }
   selectedModules?: { [id: number]: string }
+  title?: string
 }
 
 const TOTAL_STEPS = 3 // Course selection, Module selection, Quiz settings
@@ -73,8 +74,13 @@ function CreateQuiz() {
           <CourseSelectionStep
             selectedCourse={formData.selectedCourse}
             onCourseSelect={(course) =>
-              updateFormData({ selectedCourse: course })
+              updateFormData({
+                selectedCourse: course,
+                title: course.name // Auto-fill title with course name
+              })
             }
+            title={formData.title}
+            onTitleChange={(title) => updateFormData({ title })}
           />
         )
       case 2:
@@ -101,7 +107,7 @@ function CreateQuiz() {
   const isStepValid = () => {
     switch (currentStep) {
       case 1:
-        return formData.selectedCourse != null
+        return formData.selectedCourse != null && formData.title != null && formData.title.trim().length > 0
       case 2:
         return (
           formData.selectedModules != null &&


### PR DESCRIPTION
(No associated issue)

This PR implements a quiz title input field that appears after teachers select a course in the quiz creation workflow. The title input is automatically pre-filled with the course name but allows teachers to customize it before proceeding to the next step.

  ## Changes Made

  ### Frontend Components

  - CourseSelectionStep.tsx: Added title input field with auto-fill functionality
    - Input appears below course selection when a course is chosen
    - Pre-filled with selected course name
    - Includes proper labeling and helper text
    - Added data-testid for testing

###  State Management

  - create-quiz.tsx: Updated quiz creation flow to handle title state
    - Added title field to QuizFormData interface
    - Implemented auto-fill logic when course is selected
    - Updated validation to require both course selection and non-empty title

###  Backend Models

  - models.py: Updated QuizCreate model to include required title field
    - Added validation with Field(min_length=1)

 ## Testing

  - course-selection.spec.ts: Comprehensive test coverage for new functionality
    - Tests title input visibility after course selection
    - Validates auto-fill behavior with course name
    - Tests manual title editing capabilities
    - Ensures proper validation (disabled Next button for empty titles)
    - Tests state persistence across navigation steps
    - Fixed locator specificity issues to prevent test flakiness


##   Behavior

  1. Teacher selects a course from the list
  2. Title input field appears with course name pre-filled
  3. Teacher can edit the title or keep the default
  4. Next button remains disabled if title is empty or whitespace-only
  5. Title state is preserved when navigating between wizard steps
