### PR TITLE
[Refactor]: use registry for question export formatting

### DIFF
--- a/backend/src/question/types/base.py
+++ b/backend/src/question/types/base.py
@@ -93,6 +93,11 @@ class BaseQuestionType(ABC):
         """Format question data for Canvas LMS export."""
         pass
 
+    @abstractmethod
+    def format_for_export(self, data: BaseQuestionData) -> dict[str, Any]:
+        """Format question data for generic export."""
+        pass
+
 
 class Question(SQLModel, table=True):
     """

--- a/backend/src/question/types/fill_in_blank.py
+++ b/backend/src/question/types/fill_in_blank.py
@@ -233,3 +233,35 @@ class FillInBlankQuestionType(BaseQuestionType):
             "scoring_data": scoring_data,
             "points_possible": len(data.blanks),
         }
+
+    def format_for_export(self, data: BaseQuestionData) -> dict[str, Any]:
+        """
+        Format fill-in-blank data for generic export.
+
+        Args:
+            data: Validated fill-in-blank data
+
+        Returns:
+            Dictionary with fill-in-blank data for export
+        """
+        if not isinstance(data, FillInBlankData):
+            raise ValueError("Expected FillInBlankData")
+
+        # Convert blanks to a simple dict format for export
+        blanks_data = []
+        for blank in data.blanks:
+            blank_dict = {
+                "position": blank.position,
+                "correct_answer": blank.correct_answer,
+                "case_sensitive": blank.case_sensitive,
+            }
+            if blank.answer_variations:
+                blank_dict["answer_variations"] = blank.answer_variations
+            blanks_data.append(blank_dict)
+
+        return {
+            "question_text": data.question_text,
+            "blanks": blanks_data,
+            "explanation": data.explanation,
+            "question_type": self.question_type.value,
+        }

--- a/backend/src/question/types/mcq.py
+++ b/backend/src/question/types/mcq.py
@@ -130,6 +130,30 @@ class MultipleChoiceQuestionType(BaseQuestionType):
             "points_possible": 1,
         }
 
+    def format_for_export(self, data: BaseQuestionData) -> dict[str, Any]:
+        """
+        Format MCQ data for generic export.
+
+        Args:
+            data: Validated MCQ data
+
+        Returns:
+            Dictionary with MCQ data for export
+        """
+        if not isinstance(data, MultipleChoiceData):
+            raise ValueError("Expected MultipleChoiceData")
+
+        return {
+            "question_text": data.question_text,
+            "option_a": data.option_a,
+            "option_b": data.option_b,
+            "option_c": data.option_c,
+            "option_d": data.option_d,
+            "correct_answer": data.correct_answer,
+            "explanation": data.explanation,
+            "question_type": self.question_type.value,
+        }
+
     def migrate_from_legacy(self, legacy_question: Any) -> MultipleChoiceData:
         """
         Migrate from legacy Question model to new MCQ data format.

--- a/mocks/oauth_mock_server.py
+++ b/mocks/oauth_mock_server.py
@@ -1583,6 +1583,8 @@ async def debug_state():
         "access_tokens": list(access_tokens.keys()),
         "refresh_tokens": list(refresh_tokens.keys()),
         "mock_users": list(mock_users.keys()),
+        "mock_quiz_items": mock_quiz_items,
+        "mock_quizzes": mock_quizzes,
     }
 
 


### PR DESCRIPTION
This PR refactors the question export logic to improve scalability and maintainability by eliminating hardcoded conditional statements.

## Description

  The prepare_questions_for_export function in the question service previously relied on an if/elif/else block to handle the formatting of different question
  types. This created a code smell, as adding new question types would require modifying this core service logic, making the system brittle and harder to
  maintain.

## Changes


   1. New `format_for_export` Method: A new abstract method, format_for_export, has been added to the BaseQuestionType interface. This delegates the responsibility
      of formatting for export to the specific question type implementation.
   2. Concrete Implementations: The MultipleChoiceQuestionType and FillInBlankQuestionType classes now implement the format_for_export method, encapsulating their
      own export logic.
   3. Dynamic Dispatch: The prepare_questions_for_export function has been updated to use the QuestionTypeRegistry. It now dynamically calls the appropriate
      format_for_export method for each question, removing the need for conditional checks.

##  Benefits


   - Improved Scalability: New question types can be added to the system without any changes to the question service. As long as a new type implements the
     BaseQuestionType interface, it will be automatically handled by the export process.
   - Enhanced Maintainability: The code is now more modular and adheres better to the Single Responsibility Principle. Each question type is responsible for its
     own representation, making the codebase cleaner and easier to understand.
   - Increased Robustness: The system is less prone to errors when new features are added, as the core logic is decoupled from the specific question type
     implementations.