### PR TITLE
[Refactor]: Implement Soft Delete for Quizzes and Questions

### DIFF
--- a/backend/alembic/versions/a67f4ec522d2_intial_migration.py
+++ b/backend/alembic/versions/a67f4ec522d2_intial_migration.py
@@ -79,7 +79,7 @@ def upgrade():
     sa.Column('canvas_item_id', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
     sa.Column('deleted', sa.Boolean(), nullable=False),
     sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True),
-    sa.ForeignKeyConstraint(['quiz_id'], ['quiz.id'], ondelete='CASCADE'),
+    sa.ForeignKeyConstraint(['quiz_id'], ['quiz.id']),
     sa.PrimaryKeyConstraint('id')
     )
     op.create_index(op.f('ix_question_deleted'), 'question', ['deleted'], unique=False)

--- a/backend/alembic/versions/a67f4ec522d2_intial_migration.py
+++ b/backend/alembic/versions/a67f4ec522d2_intial_migration.py
@@ -1,8 +1,8 @@
-"""Initial migration
+"""Intial migration
 
-Revision ID: a051a87cf73b
+Revision ID: a67f4ec522d2
 Revises:
-Create Date: 2025-07-14 15:23:45.569310
+Create Date: 2025-07-22 10:18:41.681429
 
 """
 from alembic import op
@@ -11,7 +11,7 @@ import sqlmodel.sql.sqltypes
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = 'a051a87cf73b'
+revision = 'a67f4ec522d2'
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -35,7 +35,7 @@ def upgrade():
     op.create_index(op.f('ix_user_canvas_id'), 'user', ['canvas_id'], unique=True)
     op.create_table('quiz',
     sa.Column('id', sa.Uuid(), nullable=False),
-    sa.Column('owner_id', sa.Uuid(), nullable=False),
+    sa.Column('owner_id', sa.Uuid(), nullable=True),
     sa.Column('canvas_course_id', sa.Integer(), nullable=False),
     sa.Column('canvas_course_name', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
     sa.Column('selected_modules', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
@@ -55,10 +55,13 @@ def upgrade():
     sa.Column('canvas_quiz_id', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
     sa.Column('exported_at', sa.DateTime(timezone=True), nullable=True),
     sa.Column('generation_metadata', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
-    sa.ForeignKeyConstraint(['owner_id'], ['user.id'], ondelete='CASCADE'),
+    sa.Column('deleted', sa.Boolean(), nullable=False),
+    sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True),
+    sa.ForeignKeyConstraint(['owner_id'], ['user.id'], ),
     sa.PrimaryKeyConstraint('id')
     )
     op.create_index(op.f('ix_quiz_canvas_course_id'), 'quiz', ['canvas_course_id'], unique=False)
+    op.create_index(op.f('ix_quiz_deleted'), 'quiz', ['deleted'], unique=False)
     op.create_index(op.f('ix_quiz_failure_reason'), 'quiz', ['failure_reason'], unique=False)
     op.create_index(op.f('ix_quiz_owner_id'), 'quiz', ['owner_id'], unique=False)
     op.create_index(op.f('ix_quiz_status'), 'quiz', ['status'], unique=False)
@@ -74,9 +77,12 @@ def upgrade():
     sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
     sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
     sa.Column('canvas_item_id', sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+    sa.Column('deleted', sa.Boolean(), nullable=False),
+    sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True),
     sa.ForeignKeyConstraint(['quiz_id'], ['quiz.id'], ondelete='CASCADE'),
     sa.PrimaryKeyConstraint('id')
     )
+    op.create_index(op.f('ix_question_deleted'), 'question', ['deleted'], unique=False)
     op.create_index(op.f('ix_question_difficulty'), 'question', ['difficulty'], unique=False)
     op.create_index(op.f('ix_question_is_approved'), 'question', ['is_approved'], unique=False)
     op.create_index(op.f('ix_question_question_type'), 'question', ['question_type'], unique=False)
@@ -90,10 +96,12 @@ def downgrade():
     op.drop_index(op.f('ix_question_question_type'), table_name='question')
     op.drop_index(op.f('ix_question_is_approved'), table_name='question')
     op.drop_index(op.f('ix_question_difficulty'), table_name='question')
+    op.drop_index(op.f('ix_question_deleted'), table_name='question')
     op.drop_table('question')
     op.drop_index(op.f('ix_quiz_status'), table_name='quiz')
     op.drop_index(op.f('ix_quiz_owner_id'), table_name='quiz')
     op.drop_index(op.f('ix_quiz_failure_reason'), table_name='quiz')
+    op.drop_index(op.f('ix_quiz_deleted'), table_name='quiz')
     op.drop_index(op.f('ix_quiz_canvas_course_id'), table_name='quiz')
     op.drop_table('quiz')
     op.drop_index(op.f('ix_user_canvas_id'), table_name='user')

--- a/backend/src/question/types/base.py
+++ b/backend/src/question/types/base.py
@@ -124,9 +124,7 @@ class Question(SQLModel, table=True):
     """
 
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
-    quiz_id: uuid.UUID = Field(
-        foreign_key="quiz.id", nullable=False, ondelete="CASCADE", index=True
-    )
+    quiz_id: uuid.UUID = Field(foreign_key="quiz.id", nullable=False, index=True)
     quiz: "Quiz" = Relationship(back_populates="questions")
 
     # Question type discrimination

--- a/backend/src/question/types/base.py
+++ b/backend/src/question/types/base.py
@@ -174,6 +174,18 @@ class Question(SQLModel, table=True):
         default=None, description="Canvas quiz item ID after export"
     )
 
+    # Soft delete fields
+    deleted: bool = Field(
+        default=False,
+        index=True,
+        description="Soft delete flag for data preservation",
+    )
+    deleted_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+        description="Timestamp when question was soft deleted",
+    )
+
     def get_typed_data(
         self, question_registry: "QuestionTypeRegistry"
     ) -> BaseQuestionData:

--- a/backend/src/quiz/models.py
+++ b/backend/src/quiz/models.py
@@ -22,9 +22,7 @@ class Quiz(SQLModel, table=True):
     """Quiz model representing a quiz with questions generated from Canvas content."""
 
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
-    owner_id: uuid.UUID = Field(
-        foreign_key="user.id", nullable=False, ondelete="CASCADE", index=True
-    )
+    owner_id: uuid.UUID | None = Field(foreign_key="user.id", nullable=True, index=True)
     owner: Optional["User"] = Relationship(back_populates="quizzes")
     canvas_course_id: int = Field(index=True)
     canvas_course_name: str

--- a/backend/src/quiz/models.py
+++ b/backend/src/quiz/models.py
@@ -99,6 +99,16 @@ class Quiz(SQLModel, table=True):
     questions: list["Question"] = Relationship(
         back_populates="quiz", cascade_delete=True
     )
+    deleted: bool = Field(
+        default=False,
+        index=True,
+        description="Soft delete flag for data preservation",
+    )
+    deleted_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+        description="Timestamp when quiz was soft deleted",
+    )
 
     @property
     def module_question_distribution(self) -> dict[str, int]:

--- a/backend/tests/auth/test_user_deletion.py
+++ b/backend/tests/auth/test_user_deletion.py
@@ -1,0 +1,276 @@
+"""Tests for user deletion with quiz anonymization."""
+
+import uuid
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from src.main import app
+from src.question.models import Question
+from src.question.types import QuestionType
+from src.quiz.models import Quiz
+from tests.conftest import create_quiz_in_session, create_user_in_session
+
+
+def test_user_deletion_anonymizes_quizzes(session: Session):
+    """Test user deletion anonymizes associated quizzes."""
+    from src.auth.service import get_user_by_id
+
+    # Create user and quiz
+    user = create_user_in_session(session)
+    quiz = create_quiz_in_session(session, owner=user)
+
+    # Create questions for the quiz
+    question1 = Question(
+        quiz_id=quiz.id,
+        question_type=QuestionType.MULTIPLE_CHOICE,
+        question_data={"question_text": "Test Q1", "choices": ["A", "B"]},
+    )
+    question2 = Question(
+        quiz_id=quiz.id,
+        question_type=QuestionType.MULTIPLE_CHOICE,
+        question_data={"question_text": "Test Q2", "choices": ["C", "D"]},
+    )
+    session.add_all([question1, question2])
+    session.commit()
+    session.refresh(question1)
+    session.refresh(question2)
+
+    # Simulate user deletion by manually calling the logic
+    # (since the actual delete_user_me requires authentication)
+    user_quizzes = session.exec(select(Quiz).where(Quiz.owner_id == user.id)).all()
+
+    quiz_count = len(user_quizzes)
+    total_questions_deleted = 0
+
+    for quiz in user_quizzes:
+        # Cascade soft delete to all associated questions
+        questions = session.exec(
+            select(Question)
+            .where(Question.quiz_id == quiz.id)
+            .where(Question.deleted == False)  # noqa: E712
+        ).all()
+
+        question_count = len(questions)
+        total_questions_deleted += question_count
+
+        # Soft delete all questions
+        for question in questions:
+            question.deleted = True
+            question.deleted_at = datetime.now()
+            session.add(question)
+
+        # Anonymize the quiz by removing owner association
+        quiz.owner_id = None
+        # Soft delete the quiz to preserve data for research
+        quiz.deleted = True
+        quiz.deleted_at = datetime.now()
+        session.add(quiz)
+
+    # Hard delete the user account (complete removal)
+    session.delete(user)
+    session.commit()
+
+    # Verify user is completely deleted
+    deleted_user = get_user_by_id(session, user.id)
+    assert deleted_user is None
+
+    # Verify quiz is anonymized and soft-deleted
+    anonymized_quiz = session.exec(select(Quiz).where(Quiz.id == quiz.id)).first()
+    assert anonymized_quiz is not None
+    assert anonymized_quiz.owner_id is None  # Anonymized
+    assert anonymized_quiz.deleted is True  # Soft deleted
+    assert anonymized_quiz.deleted_at is not None
+
+    # Verify questions are soft-deleted
+    deleted_questions = session.exec(
+        select(Question).where(Question.quiz_id == quiz.id)
+    ).all()
+    assert len(deleted_questions) == 2
+    for q in deleted_questions:
+        assert q.deleted is True
+        assert q.deleted_at is not None
+
+    # Verify data is preserved for research
+    assert anonymized_quiz.title == quiz.title
+    assert anonymized_quiz.selected_modules == quiz.selected_modules
+    assert anonymized_quiz.question_count == quiz.question_count
+
+
+def test_user_deletion_preserves_quiz_data_for_research(session: Session):
+    """Test user deletion preserves all quiz data for research purposes."""
+    # Create user with comprehensive quiz data
+    user = create_user_in_session(session)
+    quiz = create_quiz_in_session(
+        session,
+        owner=user,
+        title="Research Study Quiz",
+        question_count=100,
+        llm_model="gpt-4",
+        llm_temperature=0.8,
+        selected_modules={
+            "123": {"name": "Advanced AI", "question_count": 50},
+            "456": {"name": "Machine Learning", "question_count": 50},
+        },
+    )
+
+    original_quiz_data = {
+        "title": quiz.title,
+        "question_count": quiz.question_count,
+        "llm_model": quiz.llm_model,
+        "llm_temperature": quiz.llm_temperature,
+        "selected_modules": quiz.selected_modules,
+        "canvas_course_id": quiz.canvas_course_id,
+        "canvas_course_name": quiz.canvas_course_name,
+        "status": quiz.status,
+        "language": quiz.language,
+        "question_type": quiz.question_type,
+    }
+
+    # Simulate user deletion process
+    quiz.owner_id = None  # Anonymize
+    quiz.deleted = True  # Soft delete
+    quiz.deleted_at = datetime.now()
+    session.add(quiz)
+    session.delete(user)  # Hard delete user
+    session.commit()
+
+    # Retrieve anonymized quiz
+    anonymized_quiz = session.exec(select(Quiz).where(Quiz.id == quiz.id)).first()
+
+    # Verify all research data is preserved
+    assert anonymized_quiz is not None
+    assert anonymized_quiz.owner_id is None  # Anonymized
+    assert anonymized_quiz.deleted is True  # Soft deleted
+
+    # Verify all original data is preserved for research
+    assert anonymized_quiz.title == original_quiz_data["title"]
+    assert anonymized_quiz.question_count == original_quiz_data["question_count"]
+    assert anonymized_quiz.llm_model == original_quiz_data["llm_model"]
+    assert anonymized_quiz.llm_temperature == original_quiz_data["llm_temperature"]
+    assert anonymized_quiz.selected_modules == original_quiz_data["selected_modules"]
+    assert anonymized_quiz.canvas_course_id == original_quiz_data["canvas_course_id"]
+    assert (
+        anonymized_quiz.canvas_course_name == original_quiz_data["canvas_course_name"]
+    )
+    assert anonymized_quiz.status == original_quiz_data["status"]
+    assert anonymized_quiz.language == original_quiz_data["language"]
+    assert anonymized_quiz.question_type == original_quiz_data["question_type"]
+
+
+def test_user_deletion_gdpr_compliance(session: Session):
+    """Test user deletion ensures GDPR compliance through complete anonymization."""
+    # Create user with personal data
+    user = create_user_in_session(session, name="John Doe", canvas_id=12345)
+    quiz1 = create_quiz_in_session(session, owner=user, title="John's Quiz 1")
+    quiz2 = create_quiz_in_session(session, owner=user, title="John's Quiz 2")
+
+    # Store original user data
+    user_id = user.id
+    canvas_id = user.canvas_id
+    user_name = user.name
+
+    # Simulate complete user deletion process
+    user_quizzes = session.exec(select(Quiz).where(Quiz.owner_id == user.id)).all()
+
+    # Anonymize all quizzes
+    for quiz in user_quizzes:
+        quiz.owner_id = None  # Remove personal connection
+        quiz.deleted = True
+        quiz.deleted_at = datetime.now()
+        session.add(quiz)
+
+    # Hard delete user (complete removal of PII)
+    session.delete(user)
+    session.commit()
+
+    # Verify complete user PII removal
+    from src.auth.service import get_user_by_canvas_id, get_user_by_id
+
+    deleted_user_by_id = get_user_by_id(session, user_id)
+    assert deleted_user_by_id is None
+
+    deleted_user_by_canvas = get_user_by_canvas_id(session, canvas_id)
+    assert deleted_user_by_canvas is None
+
+    # Verify no way to trace quizzes back to user
+    anonymized_quizzes = session.exec(
+        select(Quiz).where(Quiz.id.in_([quiz1.id, quiz2.id]))
+    ).all()
+
+    assert len(anonymized_quizzes) == 2
+    for quiz in anonymized_quizzes:
+        assert quiz.owner_id is None  # No connection to user
+        assert quiz.deleted is True  # Soft deleted for research
+        # Quiz titles and content preserved for research
+        assert quiz.title in ["John's Quiz 1", "John's Quiz 2"]
+
+    # Verify there's no database record that can link back to the user
+    # This ensures GDPR "right to be forgotten" compliance
+    all_quizzes = session.exec(select(Quiz).where(Quiz.owner_id == user_id)).all()
+    assert len(all_quizzes) == 0  # No quizzes linked to deleted user ID
+
+
+def test_multiple_users_deletion_isolation(session: Session):
+    """Test multiple user deletions don't affect each other's data."""
+    # Create two users with their own quizzes
+    user1 = create_user_in_session(session, name="User 1", canvas_id=111)
+    user2 = create_user_in_session(session, name="User 2", canvas_id=222)
+
+    quiz1 = create_quiz_in_session(session, owner=user1, title="User 1 Quiz")
+    quiz2 = create_quiz_in_session(session, owner=user2, title="User 2 Quiz")
+
+    # Delete user1 only
+    user1_quizzes = session.exec(select(Quiz).where(Quiz.owner_id == user1.id)).all()
+
+    for quiz in user1_quizzes:
+        quiz.owner_id = None
+        quiz.deleted = True
+        quiz.deleted_at = datetime.now()
+        session.add(quiz)
+
+    session.delete(user1)
+    session.commit()
+
+    # Verify user1 is deleted and quiz anonymized
+    from src.auth.service import get_user_by_id
+
+    deleted_user1 = get_user_by_id(session, user1.id)
+    assert deleted_user1 is None
+
+    anonymized_quiz1 = session.exec(select(Quiz).where(Quiz.id == quiz1.id)).first()
+    assert anonymized_quiz1.owner_id is None
+    assert anonymized_quiz1.deleted is True
+
+    # Verify user2 and their quiz are unaffected
+    active_user2 = get_user_by_id(session, user2.id)
+    assert active_user2 is not None
+    assert active_user2.name == "User 2"
+
+    active_quiz2 = session.exec(select(Quiz).where(Quiz.id == quiz2.id)).first()
+    assert active_quiz2.owner_id == user2.id  # Still owned by user2
+    assert active_quiz2.deleted is False  # Still active
+    assert active_quiz2.title == "User 2 Quiz"
+
+
+def test_empty_user_deletion(session: Session):
+    """Test deletion of user with no quizzes works correctly."""
+    from src.auth.service import get_user_by_id
+
+    # Create user with no quizzes
+    user = create_user_in_session(session, name="Empty User")
+    user_id = user.id
+
+    # Delete user (no quizzes to anonymize)
+    session.delete(user)
+    session.commit()
+
+    # Verify user is deleted
+    deleted_user = get_user_by_id(session, user_id)
+    assert deleted_user is None
+
+    # Verify no orphaned data
+    orphaned_quizzes = session.exec(select(Quiz).where(Quiz.owner_id == user_id)).all()
+    assert len(orphaned_quizzes) == 0


### PR DESCRIPTION
Implement comprehensive soft delete functionality for quiz and question data preservation while maintaining GDPR compliance for user deletion. This feature enables research data retention by anonymizing and soft-deleting quiz/question content when users delete their accounts, while providing hard deletion for user accounts to ensure complete PII removal.

##  Problem Statement

  The application previously performed hard deletes on all data when users deleted their accounts, resulting in:
  - Loss of valuable research data for LLM improvement and usage analytics
  - Inability to study question generation patterns across different courses and subjects
  - No preservation of anonymized quiz content that could benefit educational research
  - Permanent data loss that couldn't be recovered for legitimate research purposes

  ## Solution

  Implemented a dual deletion strategy with comprehensive soft delete system:

  ### User Accounts: Hard Delete (GDPR Compliant)

  - Complete removal of all user PII (name, Canvas tokens, user ID)
  - Immediate JWT token invalidation
  - No recovery possible (ensures "right to be forgotten")

  ### Quiz/Question Data: Soft Delete + Anonymization

  - Anonymization: Quiz owner_id set to NULL (removes personal connection)
  - Soft delete: Records marked as deleted=true with deleted_at timestamp
  - Data preservation: All quiz content, settings, and question data retained
  - Research access: include_deleted parameter allows accessing soft-deleted data

  ## Technical Implementation

 ### Database Schema Changes

  - Quiz Model: Added deleted (bool), deleted_at (datetime), made owner_id nullable
  - Question Model: Added deleted (bool), deleted_at (datetime)
  - Foreign Key: Removed CASCADE constraint from Quiz.owner_id to support anonymization

  ### Service Layer Updates

  - Default Filtering: All query methods filter out soft-deleted records by default
  - Research Access: include_deleted=True parameter allows accessing soft-deleted data
  - Cascade Logic: Quiz soft delete automatically cascades to associated questions
  - Query Optimization: Added database indexes on deleted fields for performance

  ## User Deletion Workflow

  # User deletion process:
  1. Find all user's quizzes
  2. For each quiz:
     - Cascade soft delete all questions (deleted=True, deleted_at=now())
     - Anonymize quiz (owner_id=NULL)
     - Soft delete quiz (deleted=True, deleted_at=now())
  3. Hard delete user account (complete removal)

  ## GDPR Compliance

  - Complete anonymization: No way to trace soft-deleted data back to original user
  - PII removal: All personally identifiable information permanently deleted
  - Data retention: Anonymous research data preserved for legitimate purposes
  - Audit trail: Deletion timestamps for compliance reporting

 ## Benefits

  - Question generation patterns preserved for LLM improvement
  - Usage statistics available without user identification
  - Course content analysis possible with anonymized data
  - Educational research supported with privacy-compliant datase
  - GDPR compliant user deletion with complete PII removal
  - Anonymization ensures no personal data linkage
  - Audit trail with deletion timestamps
  - Transparent data handling with clear documentation
  - Data asset preservation for future research initiatives
  - ML model improvement using anonymized question/quiz patterns
  - Educational insights from aggregated usage data
  - Compliance readiness for privacy regulations

  ## Database Migration Notes

 Database migration required to add soft delete fields and modify foreign key constraints. The migration:
  - Adds deleted (boolean, default false) and deleted_at (timestamp) to Quiz and Question tables
  - Makes Quiz.owner_id nullable to support anonymization
  - Removes CASCADE delete constraint from Quiz.owner_id foreign key
  - Adds database indexes on deleted fields for query performance
