### PR TITLE
[Fix]: increase modules per request from 10 to 50

### DIFF
--- a/backend/src/canvas/url_builder.py
+++ b/backend/src/canvas/url_builder.py
@@ -48,8 +48,9 @@ class CanvasURLBuilder:
 
     def modules(self, course_id: int, module_id: int | None = None) -> str:
         """Build modules URL."""
-        base = f"{self.courses(course_id)}/modules?per_page=50"
-        return f"{base}/{module_id}" if module_id else base
+        base = f"{self.courses(course_id)}/modules"
+        base_list = f"{self.courses(course_id)}/modules/?per_page=50"
+        return f"{base}/{module_id}" if module_id else base_list
 
     def module_items(self, course_id: int, module_id: int) -> str:
         """Build module items URL."""


### PR DESCRIPTION
Simple fix where the url param ?per_page=50 is appended to the modules endpoint in Canvas. 

If in the future 50 modules are not enough to fetch all modules in a course, we may handle pagination with Link headers. Read: https://documentation.instructure.com/doc/api/file.pagination.html