### PR TITLE
[Feat]: add explanation field to export

### DIFF
--- a/backend/src/canvas/constants.py
+++ b/backend/src/canvas/constants.py
@@ -46,6 +46,9 @@ class CanvasScoringAlgorithm:
     TEXT_CONTAINS_ANSWER = (
         "TextContainsAnswer"  # Used for fill-in-blank individual answers
     )
+    TEXT_IN_CHOICES = (
+        "TextInChoices"  # Used for fill-in-blank with multiple answer choices
+    )
 
 
 class CanvasInteractionType:

--- a/backend/src/question/types/categorization.py
+++ b/backend/src/question/types/categorization.py
@@ -352,10 +352,9 @@ class CategorizationQuestionType(BaseQuestionType):
                 "value": scoring_value,
                 "score_method": "all_or_nothing",
             },
-            "answer_feedback": {},
             "scoring_algorithm": CanvasScoringAlgorithm.CATEGORIZATION,
             "interaction_type_slug": CanvasInteractionType.CATEGORIZATION,
-            "feedback": {},
+            "feedback": {"neutral": data.explanation} if data.explanation else {},
             "points_possible": points_possible,
         }
 

--- a/backend/src/question/types/matching.py
+++ b/backend/src/question/types/matching.py
@@ -238,10 +238,9 @@ class MatchingQuestionType(BaseQuestionType):
                     "distractors": data.distractors or [],
                 },
             },
-            "answer_feedback": {},
             "scoring_algorithm": CanvasScoringAlgorithm.PARTIAL_DEEP,
             "interaction_type_slug": CanvasInteractionType.MATCHING,
-            "feedback": {},
+            "feedback": {"neutral": data.explanation} if data.explanation else {},
             "points_possible": len(data.pairs),
         }
 

--- a/backend/src/question/types/mcq.py
+++ b/backend/src/question/types/mcq.py
@@ -151,10 +151,9 @@ class MultipleChoiceQuestionType(BaseQuestionType):
                 "vary_points_by_answer": False,
             },
             "scoring_data": {"value": f"choice_{correct_index + 1}"},
-            "answer_feedback": {},
             "scoring_algorithm": CanvasScoringAlgorithm.EQUIVALENCE,
             "interaction_type_slug": CanvasInteractionType.CHOICE,
-            "feedback": {},
+            "feedback": {"neutral": data.explanation} if data.explanation else {},
             "points_possible": 1,
         }
 

--- a/backend/src/question/types/true_false.py
+++ b/backend/src/question/types/true_false.py
@@ -98,10 +98,9 @@ class TrueFalseQuestionType(BaseQuestionType):
             },
             "properties": {},
             "scoring_data": {"value": data.correct_answer},
-            "answer_feedback": {},
             "scoring_algorithm": CanvasScoringAlgorithm.EQUIVALENCE,
             "interaction_type_slug": CanvasInteractionType.TRUE_FALSE,
-            "feedback": {},
+            "feedback": {"neutral": data.explanation} if data.explanation else {},
             "points_possible": 1,
         }
 

--- a/backend/tests/question/types/test_mcq.py
+++ b/backend/tests/question/types/test_mcq.py
@@ -505,6 +505,9 @@ def test_multiple_choice_question_type_format_for_canvas():
     assert properties["shuffle_rules"]["choices"]["shuffled"] is True
     assert properties["vary_points_by_answer"] is False
 
+    # Validate feedback - should be empty when no explanation
+    assert result["feedback"] == {}
+
 
 def test_multiple_choice_question_type_format_for_canvas_different_answers():
     """Test Canvas formatting with different correct answers."""
@@ -594,6 +597,87 @@ def test_multiple_choice_question_type_format_for_canvas_wrong_type():
 
     with pytest.raises(ValueError, match="Expected MultipleChoiceData"):
         question_type.format_for_canvas("wrong_type")
+
+
+def test_multiple_choice_question_type_format_for_canvas_with_explanation():
+    """Test Canvas export formatting with explanation."""
+    from src.question.types.mcq import (
+        MultipleChoiceData,
+        MultipleChoiceQuestionType,
+    )
+
+    question_type = MultipleChoiceQuestionType()
+    data = MultipleChoiceData(
+        question_text="What is the capital of France?",
+        option_a="Paris",
+        option_b="London",
+        option_c="Berlin",
+        option_d="Madrid",
+        correct_answer="A",
+        explanation="Paris is the capital city of France and its largest city.",
+    )
+
+    result = question_type.format_for_canvas(data)
+
+    # Validate feedback contains explanation
+    assert "feedback" in result
+    assert "neutral" in result["feedback"]
+    assert (
+        result["feedback"]["neutral"]
+        == "Paris is the capital city of France and its largest city."
+    )
+
+
+def test_multiple_choice_question_type_format_for_canvas_empty_explanation():
+    """Test Canvas export formatting with empty string explanation."""
+    from src.question.types.mcq import (
+        MultipleChoiceData,
+        MultipleChoiceQuestionType,
+    )
+
+    question_type = MultipleChoiceQuestionType()
+    data = MultipleChoiceData(
+        question_text="What is the capital of France?",
+        option_a="Paris",
+        option_b="London",
+        option_c="Berlin",
+        option_d="Madrid",
+        correct_answer="A",
+        explanation="",
+    )
+
+    result = question_type.format_for_canvas(data)
+
+    # Validate feedback is empty dict when explanation is empty string
+    assert result["feedback"] == {}
+
+
+def test_multiple_choice_question_type_format_for_canvas_max_explanation():
+    """Test Canvas export formatting with maximum length explanation."""
+    from src.question.types.mcq import (
+        MultipleChoiceData,
+        MultipleChoiceQuestionType,
+    )
+
+    question_type = MultipleChoiceQuestionType()
+    max_explanation = "x" * 1000  # Maximum allowed length
+    data = MultipleChoiceData(
+        question_text="What is the capital of France?",
+        option_a="Paris",
+        option_b="London",
+        option_c="Berlin",
+        option_d="Madrid",
+        correct_answer="A",
+        explanation=max_explanation,
+    )
+
+    result = question_type.format_for_canvas(data)
+
+    # Validate feedback contains full explanation
+    assert "feedback" in result
+    assert "neutral" in result["feedback"]
+    assert result["feedback"]["neutral"] == max_explanation
+    assert len(result["feedback"]["neutral"]) == 1000
 
 
 def test_multiple_choice_question_type_format_for_export():


### PR DESCRIPTION
- Add explanation text in question model to feedback neutral upon exporting to canvas
- Fix FIll in the Blank question to be compatible with Canvas API