### PR TITLE
[Fix]: Implement graceful Canvas API error handling with retry functionality

### DIFF
--- a/frontend/src/components/QuizCreation/CourseSelectionStep.tsx
+++ b/frontend/src/components/QuizCreation/CourseSelectionStep.tsx
@@ -1,30 +1,31 @@
 import {
   Alert,
   Box,
+  Button,
   Card,
   HStack,
   Input,
   RadioGroup,
   Text,
   VStack,
-} from "@chakra-ui/react"
-import { useQuery } from "@tanstack/react-query"
+} from "@chakra-ui/react";
+import { useQuery } from "@tanstack/react-query";
 
-import { CanvasService } from "@/client"
-import { LoadingSkeleton } from "@/components/Common"
-import { Field } from "@/components/ui/field"
-import { analyzeCanvasError } from "@/lib/utils"
+import { CanvasService } from "@/client";
+import { LoadingSkeleton } from "@/components/Common";
+import { Field } from "@/components/ui/field";
+import { analyzeCanvasError } from "@/lib/utils";
 
 interface Course {
-  id: number
-  name: string
+  id: number;
+  name: string;
 }
 
 interface CourseSelectionStepProps {
-  selectedCourse?: Course
-  onCourseSelect: (course: Course) => void
-  title?: string
-  onTitleChange: (title: string) => void
+  selectedCourse?: Course;
+  onCourseSelect: (course: Course) => void;
+  title?: string;
+  onTitleChange: (title: string) => void;
 }
 
 export function CourseSelectionStep({
@@ -37,40 +38,53 @@ export function CourseSelectionStep({
     data: courses,
     isLoading,
     error,
+    refetch,
+    isFetching,
   } = useQuery({
     queryKey: ["canvas-courses"],
     queryFn: CanvasService.getCourses,
     retry: 1, // Only retry once instead of default 3 times
     retryDelay: 1000, // Wait 1 second between retries
     staleTime: 30000, // Consider data stale after 30 seconds
-  })
+  });
 
-  if (isLoading) {
+  if (isLoading || isFetching) {
     return (
       <VStack gap={4} align="stretch">
         <Text fontSize="lg" fontWeight="semibold">
-          Loading your courses...
+          {isLoading ? "Loading your courses..." : "Retrying..."}
         </Text>
         <LoadingSkeleton height="60px" lines={3} />
       </VStack>
-    )
+    );
   }
 
   if (error) {
-    const errorInfo = analyzeCanvasError(error)
+    const errorInfo = analyzeCanvasError(error);
 
     return (
       <Alert.Root status="error">
         <Alert.Indicator />
         <Alert.Title>Failed to load courses</Alert.Title>
         <Alert.Description>
-          <Text mb={2}>{errorInfo.userFriendlyMessage}</Text>
-          <Text fontSize="sm" color="gray.600">
-            {errorInfo.actionableGuidance}
-          </Text>
+          <VStack gap={3} align="stretch">
+            <Text>{errorInfo.userFriendlyMessage}</Text>
+            <Text fontSize="sm" color="gray.600">
+              {errorInfo.actionableGuidance}
+            </Text>
+            <Button
+              variant="solid"
+              size="sm"
+              onClick={() => refetch()}
+              disabled={isFetching}
+              loading={isFetching}
+            >
+              Try Again
+            </Button>
+          </VStack>
         </Alert.Description>
       </Alert.Root>
-    )
+    );
   }
 
   if (!courses || courses.length === 0) {
@@ -83,7 +97,7 @@ export function CourseSelectionStep({
           check your Canvas account or contact your administrator.
         </Alert.Description>
       </Alert.Root>
-    )
+    );
   }
 
   return (
@@ -114,7 +128,7 @@ export function CourseSelectionStep({
               }
               bg={selectedCourse?.id === course.id ? "blue.50" : "white"}
               onClick={() => {
-                onCourseSelect(course)
+                onCourseSelect(course);
               }}
               data-testid={`course-card-${course.id}`}
             >
@@ -164,5 +178,5 @@ export function CourseSelectionStep({
         </VStack>
       )}
     </VStack>
-  )
+  );
 }

--- a/frontend/src/components/QuizCreation/ModuleSelectionStep.tsx
+++ b/frontend/src/components/QuizCreation/ModuleSelectionStep.tsx
@@ -1,4 +1,4 @@
-import { Checkbox } from "@/components/ui/checkbox"
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Alert,
   Box,
@@ -7,37 +7,37 @@ import {
   HStack,
   Text,
   VStack,
-} from "@chakra-ui/react"
-import { useQuery } from "@tanstack/react-query"
-import type React from "react"
-import { useCallback, useMemo, useState } from "react"
+} from "@chakra-ui/react";
+import { useQuery } from "@tanstack/react-query";
+import type React from "react";
+import { useCallback, useMemo, useState } from "react";
 
-import { CanvasService } from "@/client"
-import { LoadingSkeleton } from "@/components/Common"
-import { analyzeCanvasError } from "@/lib/utils"
-import { ManualModuleDialog } from "./ManualModuleDialog"
+import { CanvasService } from "@/client";
+import { LoadingSkeleton } from "@/components/Common";
+import { analyzeCanvasError } from "@/lib/utils";
+import { ManualModuleDialog } from "./ManualModuleDialog";
 
 interface Module {
-  id: number
-  name: string
+  id: number;
+  name: string;
 }
 
 interface ManualModule {
-  id: string
-  name: string
-  contentPreview: string
-  fullContent: string
-  wordCount: number
-  processingMetadata?: Record<string, any>
-  isManual: true
+  id: string;
+  name: string;
+  contentPreview: string;
+  fullContent: string;
+  wordCount: number;
+  processingMetadata?: Record<string, any>;
+  isManual: true;
 }
 
 interface ModuleSelectionStepProps {
-  courseId: number
-  selectedModules: { [id: string]: string }
-  manualModules?: ManualModule[]
-  onModulesSelect: (modules: { [id: string]: string }) => void
-  onManualModuleAdd?: (module: ManualModule) => void
+  courseId: number;
+  selectedModules: { [id: string]: string };
+  manualModules?: ManualModule[];
+  onModulesSelect: (modules: { [id: string]: string }) => void;
+  onManualModuleAdd?: (module: ManualModule) => void;
 }
 
 export function ModuleSelectionStep({
@@ -47,7 +47,7 @@ export function ModuleSelectionStep({
   onModulesSelect,
   onManualModuleAdd,
 }: ModuleSelectionStepProps) {
-  const [isManualDialogOpen, setIsManualDialogOpen] = useState(false)
+  const [isManualDialogOpen, setIsManualDialogOpen] = useState(false);
   // Show message if no course is selected
   if (!courseId || courseId <= 0) {
     return (
@@ -58,13 +58,15 @@ export function ModuleSelectionStep({
           Please go back to the previous step and select a course first.
         </Alert.Description>
       </Alert.Root>
-    )
+    );
   }
 
   const {
     data: modules,
     isLoading,
     error,
+    refetch,
+    isFetching,
   } = useQuery({
     queryKey: ["canvas-modules", courseId],
     queryFn: () => CanvasService.getCourseModules({ courseId }),
@@ -72,32 +74,32 @@ export function ModuleSelectionStep({
     retryDelay: 1000,
     staleTime: 30000,
     enabled: !!courseId && courseId > 0,
-  })
+  });
 
   const handleModuleToggle = useCallback(
     (module: Module | ManualModule, checked: boolean) => {
-      const newSelectedModules = { ...selectedModules }
-      const moduleId = String(module.id)
+      const newSelectedModules = { ...selectedModules };
+      const moduleId = String(module.id);
 
       if (checked) {
-        newSelectedModules[moduleId] = module.name
+        newSelectedModules[moduleId] = module.name;
       } else {
-        delete newSelectedModules[moduleId]
+        delete newSelectedModules[moduleId];
       }
 
-      onModulesSelect(newSelectedModules)
+      onModulesSelect(newSelectedModules);
     },
-    [selectedModules, onModulesSelect],
-  )
+    [selectedModules, onModulesSelect]
+  );
 
   const handleManualModuleCreated = useCallback(
     (moduleData: {
-      moduleId: string
-      name: string
-      contentPreview: string
-      fullContent: string
-      wordCount: number
-      processingMetadata?: Record<string, any>
+      moduleId: string;
+      name: string;
+      contentPreview: string;
+      fullContent: string;
+      wordCount: number;
+      processingMetadata?: Record<string, any>;
     }) => {
       const manualModule: ManualModule = {
         id: moduleData.moduleId,
@@ -107,50 +109,61 @@ export function ModuleSelectionStep({
         wordCount: moduleData.wordCount,
         processingMetadata: moduleData.processingMetadata,
         isManual: true,
-      }
+      };
 
       // Add the manual module to the list
-      onManualModuleAdd?.(manualModule)
+      onManualModuleAdd?.(manualModule);
 
       // Automatically select the new manual module
-      const newSelectedModules = { ...selectedModules }
-      newSelectedModules[moduleData.moduleId] = moduleData.name
-      onModulesSelect(newSelectedModules)
+      const newSelectedModules = { ...selectedModules };
+      newSelectedModules[moduleData.moduleId] = moduleData.name;
+      onModulesSelect(newSelectedModules);
     },
-    [selectedModules, onModulesSelect, onManualModuleAdd],
-  )
+    [selectedModules, onModulesSelect, onManualModuleAdd]
+  );
 
   const selectedCount = useMemo(
     () => Object.keys(selectedModules).length,
-    [selectedModules],
-  )
+    [selectedModules]
+  );
 
-  if (isLoading) {
+  if (isLoading || isFetching) {
     return (
       <VStack gap={4} align="stretch">
         <Text fontSize="lg" fontWeight="semibold">
-          Loading course modules...
+          {isLoading ? "Loading course modules..." : "Retrying..."}
         </Text>
         <LoadingSkeleton height="60px" lines={4} />
       </VStack>
-    )
+    );
   }
 
   if (error) {
-    const errorInfo = analyzeCanvasError(error)
+    const errorInfo = analyzeCanvasError(error);
 
     return (
       <Alert.Root status="error">
         <Alert.Indicator />
         <Alert.Title>Failed to load course modules</Alert.Title>
         <Alert.Description>
-          <Text mb={2}>{errorInfo.userFriendlyMessage}</Text>
-          <Text fontSize="sm" color="gray.600">
-            {errorInfo.actionableGuidance}
-          </Text>
+          <VStack gap={3} align="stretch">
+            <Text>{errorInfo.userFriendlyMessage}</Text>
+            <Text fontSize="sm" color="gray.600">
+              {errorInfo.actionableGuidance}
+            </Text>
+            <Button
+              variant="solid"
+              size="sm"
+              onClick={() => refetch()}
+              disabled={isFetching}
+              loading={isFetching}
+            >
+              Try Again
+            </Button>
+          </VStack>
         </Alert.Description>
       </Alert.Root>
-    )
+    );
   }
 
   if (!modules || modules.length === 0) {
@@ -163,7 +176,7 @@ export function ModuleSelectionStep({
           the course in Canvas before generating a quiz.
         </Alert.Description>
       </Alert.Root>
-    )
+    );
   }
 
   return (
@@ -208,8 +221,8 @@ export function ModuleSelectionStep({
               colorScheme="green"
               variant="outline"
               onClick={(e) => {
-                e.stopPropagation()
-                setIsManualDialogOpen(true)
+                e.stopPropagation();
+                setIsManualDialogOpen(true);
               }}
             >
               Add Module
@@ -229,7 +242,7 @@ export function ModuleSelectionStep({
             borderColor={selectedModules[module.id] ? "blue.500" : "gray.200"}
             bg={selectedModules[module.id] ? "blue.50" : "white"}
             onClick={() => {
-              handleModuleToggle(module, !selectedModules[module.id])
+              handleModuleToggle(module, !selectedModules[module.id]);
             }}
             data-testid={`module-card-${module.id}`}
           >
@@ -263,7 +276,7 @@ export function ModuleSelectionStep({
             borderColor={selectedModules[module.id] ? "blue.500" : "gray.200"}
             bg={selectedModules[module.id] ? "blue.50" : "white"}
             onClick={() => {
-              handleModuleToggle(module, !selectedModules[module.id])
+              handleModuleToggle(module, !selectedModules[module.id]);
             }}
             data-testid={`manual-module-card-${module.id}`}
           >
@@ -321,5 +334,5 @@ export function ModuleSelectionStep({
         onModuleCreated={handleManualModuleCreated}
       />
     </VStack>
-  )
+  );
 }

--- a/frontend/src/lib/utils/errors.ts
+++ b/frontend/src/lib/utils/errors.ts
@@ -49,6 +49,17 @@ export function analyzeCanvasError(error: unknown): CanvasErrorInfo {
 
   const isCanvasApiCall = error.url?.includes("/canvas") || false
 
+  // Handle 401 errors from Canvas API calls (token expired)
+  if (error.status === 401 && isCanvasApiCall) {
+    return {
+      isCanvasError: true,
+      isPermissionError: true,
+      userFriendlyMessage: "Your Canvas session has expired",
+      actionableGuidance:
+        "Please try again, or refresh your browser and log back in if the problem persists.",
+    }
+  }
+
   // Handle 403 errors from Canvas API calls
   if (error.status === 403 && isCanvasApiCall) {
     return {


### PR DESCRIPTION
- Modified global 401 handler to exclude Canvas API errors from automatic redirect
- Added Canvas 401 handling in error analysis with user-friendly messaging
- Enhanced CourseSelectionStep with retry button and improved loading states
- Enhanced ModuleSelectionStep with retry button and improved loading states
- Canvas authentication failures now show retry UI instead of forcing login redirect
- Maintains existing global 401 handling for non-Canvas API endpoints

Fixes #150 - unauthorized error on course and module fetching