### PR TITLE
[Fix]: UUID failures in Canvas

### DIFF
--- a/backend/src/question/types/fill_in_blank.py
+++ b/backend/src/question/types/fill_in_blank.py
@@ -55,7 +55,48 @@ class BlankData(BaseModel):
                 seen.add(variation)
                 unique_variations.append(variation)
 
+        # Remove float equivalents of integers (e.g., remove "1.0" if "1" exists)
+        unique_variations = cls._remove_float_integer_duplicates_static(
+            unique_variations
+        )
+
         return unique_variations if unique_variations else None
+
+    @staticmethod
+    def _remove_float_integer_duplicates_static(answers: list[str]) -> list[str]:
+        """
+        Static version for use in validators.
+
+        Remove float representations that are equivalent to existing integers.
+        For example, if both "1" and "1.0" exist in the list, remove "1.0".
+        """
+        if not answers:
+            return answers
+
+        filtered_answers = []
+        seen_integers = set()
+
+        # Process answers to remove float equivalents of integers
+        for answer in answers:
+            try:
+                # Try to parse as float
+                float_val = float(answer)
+                # Check if it's actually an integer (no decimal part)
+                if float_val.is_integer():
+                    int_val = int(float_val)
+                    if int_val not in seen_integers:
+                        seen_integers.add(int_val)
+                        # Prefer integer format over float format
+                        filtered_answers.append(str(int_val))
+                    # Skip float representations like "1.0" if we already have "1"
+                else:
+                    # It's a float with decimal part, keep it
+                    filtered_answers.append(answer)
+            except (ValueError, TypeError):
+                # Not a number, keep as is
+                filtered_answers.append(answer)
+
+        return filtered_answers
 
 
 class FillInBlankData(BaseQuestionData):

--- a/backend/tests/canvas/test_canvas_service.py
+++ b/backend/tests/canvas/test_canvas_service.py
@@ -271,16 +271,16 @@ def test_convert_question_to_canvas_format_multiple_choice():
 
 
 @pytest.mark.parametrize(
-    "correct_letter,expected_choice",
+    "correct_letter,expected_index",
     [
-        ("A", "choice_1"),
-        ("B", "choice_2"),
-        ("C", "choice_3"),
-        ("D", "choice_4"),
-        ("X", "choice_1"),  # Invalid answer defaults to A
+        ("A", 0),  # A = index 0
+        ("B", 1),  # B = index 1
+        ("C", 2),  # C = index 2
+        ("D", 3),  # D = index 3
+        ("X", 0),  # Invalid answer defaults to A = index 0
     ],
 )
-def test_convert_question_correct_answer_mapping(correct_letter, expected_choice):
+def test_convert_question_correct_answer_mapping(correct_letter, expected_index):
     """Test correct answer mapping for different options."""
     from src.canvas.service import convert_question_to_canvas_format
 
@@ -296,9 +296,15 @@ def test_convert_question_correct_answer_mapping(correct_letter, expected_choice
     }
 
     result = convert_question_to_canvas_format(question, 1)
-    scoring_value = result["item"]["entry"]["scoring_data"]["value"]
 
-    assert scoring_value == expected_choice
+    # Get the choices and scoring data
+    entry = result["item"]["entry"]
+    choices = entry["interaction_data"]["choices"]
+    scoring_value = entry["scoring_data"]["value"]
+
+    # The scoring value should match the UUID of the choice at the expected index
+    expected_choice_id = choices[expected_index]["id"]
+    assert scoring_value == expected_choice_id
 
 
 @pytest.mark.asyncio
@@ -617,9 +623,12 @@ def test_convert_question_to_canvas_format_multiple_choice():
     assert "choices" in interaction_data
     assert len(interaction_data["choices"]) == 4
 
-    # Check scoring data
+    # Check scoring data - should be UUID format now
     scoring_data = entry["scoring_data"]
-    assert scoring_data["value"] == "choice_2"  # B = index 1, so choice_2
+    # The correct answer should correspond to option B (index 1 in choices)
+    choices = interaction_data["choices"]
+    option_b_id = choices[1]["id"]  # Get the UUID for option B
+    assert scoring_data["value"] == option_b_id
 
 
 def test_convert_question_to_canvas_format_unsupported_type():


### PR DESCRIPTION
Modified:
- Add uuid for mcq choices
- 5-numeric id for first 4 pairs in matching and uuid afterwards