### PR TITLE
feat: migrate from OpenAI SDK to Azure OpenAI SDK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,11 @@ CANVAS_BASE_URL=https://uit.instructure.com
 # Leave empty to show all courses
 CANVAS_COURSE_PREFIX_FILTER=
 
+# Azure OpenAI Settings
+AZURE_OPENAI_API_KEY=
+AZURE_OPENAI_ENDPOINT=
+AZURE_OPENAI_API_VERSION=
+
 # Default Admin User (optional, created by prestart script)
 FIRST_SUPERUSER=admin@example.com
 FIRST_SUPERUSER_PASSWORD=admin

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -90,8 +90,10 @@ class Settings(BaseSettings):
     # Course filtering
     CANVAS_COURSE_PREFIX_FILTER: str = ""
 
-    # LLM settings
-    OPENAI_SECRET_KEY: str | None = None
+    # Azure OpenAI settings
+    AZURE_OPENAI_API_KEY: str | None = None
+    AZURE_OPENAI_ENDPOINT: str | None = None
+    AZURE_OPENAI_API_VERSION: str | None = None
     LLM_API_TIMEOUT: float = 500.0  # LLM request timeout in seconds (5 minutes)
 
     # Module-based question generation settings

--- a/backend/src/question/config/service.py
+++ b/backend/src/question/config/service.py
@@ -376,7 +376,7 @@ class ConfigurationService:
         config = QuestionGenerationConfig()
 
         # Add provider configurations based on available settings
-        if settings.OPENAI_SECRET_KEY:
+        if settings.AZURE_OPENAI_API_KEY:
             openai_config = LLMConfiguration(
                 provider=LLMProvider.OPENAI,
                 model=DEFAULT_OPENAI_MODEL,
@@ -386,7 +386,11 @@ class ConfigurationService:
                 initial_retry_delay=settings.INITIAL_RETRY_DELAY,
                 max_retry_delay=settings.MAX_RETRY_DELAY,
                 retry_backoff_factor=settings.RETRY_BACKOFF_FACTOR,
-                provider_settings={"api_key": settings.OPENAI_SECRET_KEY},
+                provider_settings={
+                    "api_key": settings.AZURE_OPENAI_API_KEY,
+                    "azure_endpoint": settings.AZURE_OPENAI_ENDPOINT,
+                    "api_version": settings.AZURE_OPENAI_API_VERSION,
+                },
             )
             config.provider_configs[LLMProvider.OPENAI] = openai_config
 
@@ -427,8 +431,8 @@ class ConfigurationService:
 
         # Fallback for providers not in default config
         if provider == LLMProvider.OPENAI:
-            if not settings.OPENAI_SECRET_KEY:
-                raise ValueError("OpenAI API key not configured")
+            if not settings.AZURE_OPENAI_API_KEY:
+                raise ValueError("Azure OpenAI API key not configured")
 
             return LLMConfiguration(
                 provider=LLMProvider.OPENAI,
@@ -436,7 +440,11 @@ class ConfigurationService:
                 temperature=DEFAULT_TEMPERATURE,
                 timeout=settings.LLM_API_TIMEOUT,
                 max_retries=settings.MAX_RETRIES,
-                provider_settings={"api_key": settings.OPENAI_SECRET_KEY},
+                provider_settings={
+                    "api_key": settings.AZURE_OPENAI_API_KEY,
+                    "azure_endpoint": settings.AZURE_OPENAI_ENDPOINT,
+                    "api_version": settings.AZURE_OPENAI_API_VERSION,
+                },
             )
 
         else:

--- a/backend/src/question/providers/base.py
+++ b/backend/src/question/providers/base.py
@@ -13,8 +13,8 @@ from src.config import get_logger
 logger = get_logger("llm_provider")
 
 
-# Default LLM Configuration Constants
-DEFAULT_OPENAI_MODEL = "gpt-5-mini-2025-08-07"
+# Default LLM Configuration Constants (Azure deployment name)
+DEFAULT_OPENAI_MODEL = "gpt-5-mini"
 DEFAULT_TEMPERATURE = 1.0
 
 

--- a/backend/src/question/providers/registry.py
+++ b/backend/src/question/providers/registry.py
@@ -263,7 +263,7 @@ class LLMProviderRegistry:
             from .mock_provider import MockProvider
             from .openai_provider import OpenAIProvider
 
-            if settings.OPENAI_SECRET_KEY:
+            if settings.AZURE_OPENAI_API_KEY:
                 openai_config = LLMConfiguration(
                     provider=LLMProvider.OPENAI,
                     model=DEFAULT_OPENAI_MODEL,
@@ -273,7 +273,11 @@ class LLMProviderRegistry:
                     initial_retry_delay=settings.INITIAL_RETRY_DELAY,
                     max_retry_delay=settings.MAX_RETRY_DELAY,
                     retry_backoff_factor=settings.RETRY_BACKOFF_FACTOR,
-                    provider_settings={"api_key": settings.OPENAI_SECRET_KEY},
+                    provider_settings={
+                        "api_key": settings.AZURE_OPENAI_API_KEY,
+                        "azure_endpoint": settings.AZURE_OPENAI_ENDPOINT,
+                        "api_version": settings.AZURE_OPENAI_API_VERSION,
+                    },
                 )
 
                 self.register_provider(


### PR DESCRIPTION
Migrate the OpenAI provider to use Azure OpenAI with LangChain's AzureChatOpenAI client. This change enables the application to use Azure-hosted OpenAI models with API key authentication.


Breaking Changes:
- Environment variable renamed: OPENAI_SECRET_KEY → AZURE_OPENAI_API_KEY
- New required environment variables:
  - AZURE_OPENAI_ENDPOINT: Azure OpenAI resource endpoint
  - AZURE_OPENAI_API_VERSION: API version (e.g., 2024-12-01-preview)
- Model configuration now uses Azure deployment names instead of OpenAI model IDs
- Default model changed from "gpt-5-mini-2025-08-07" to "gpt-5-mini" (deployment name)

Changes:
- Updated OpenAI provider to use AzureChatOpenAI client
- Modified provider initialization to accept Azure-specific parameters
- Updated error messages to reference Azure OpenAI
- Added Azure endpoint and API version configuration
- Updated all tests to mock AzureChatOpenAI instead of ChatOpenAI
- Modified configuration service and registry to use new Azure settings

Migration Guide:
Users must update their .env file with:
1. Rename OPENAI_SECRET_KEY to AZURE_OPENAI_API_KEY
2. Add AZURE_OPENAI_ENDPOINT with your Azure endpoint URL
3. Add AZURE_OPENAI_API_VERSION (optional, defaults in code)