### PR TITLE
fix: increase Node memory limit and support multiple fill-in-blank

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,6 +11,8 @@ COPY ./ /app/
 
 ARG VITE_API_URL=${VITE_API_URL}
 
+ENV NODE_OPTIONS="--max-old-space-size=3072"
+
 RUN npm run build
 
 


### PR DESCRIPTION
…swers

- Set NODE_OPTIONS max-old-space-size to 3GB in frontend Dockerfile
- Update oauth mock server to accept list of strings for fill-in-blank answers
- Add TextInChoices scoring algorithm support