### PR TITLE
feat: add language preference step to onboarding

### DIFF
--- a/frontend/src/components/Onboarding/OnboardingModal.tsx
+++ b/frontend/src/components/Onboarding/OnboardingModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogRoot,
 } from "../ui/dialog"
 import { FeatureStep } from "./steps/FeatureStep"
+import { LanguagePreferenceStep } from "./steps/LanguagePreferenceStep"
 import { PrivacyPolicyStep } from "./steps/PrivacyPolicyStep"
 import { SetupStep } from "./steps/SetupStep"
 import { WelcomeStep } from "./steps/WelcomeStep"
@@ -29,7 +30,7 @@ export const OnboardingModal = ({
   onComplete,
 }: OnboardingModalProps) => {
   const { t } = useTranslation("common")
-  const totalSteps = 4
+  const totalSteps = 5
   const progressValue = (currentStep / totalSteps) * 100
 
   const renderCurrentStep = () => {
@@ -37,10 +38,12 @@ export const OnboardingModal = ({
       case 1:
         return <WelcomeStep />
       case 2:
-        return <SetupStep />
+        return <LanguagePreferenceStep />
       case 3:
-        return <FeatureStep />
+        return <SetupStep />
       case 4:
+        return <FeatureStep />
+      case 5:
         return <PrivacyPolicyStep />
       default:
         return <WelcomeStep />

--- a/frontend/src/components/Onboarding/steps/LanguagePreferenceStep.tsx
+++ b/frontend/src/components/Onboarding/steps/LanguagePreferenceStep.tsx
@@ -1,0 +1,16 @@
+import LanguagePreference from "@/components/UserSettings/LanguagePreference"
+import { Stack, Text } from "@chakra-ui/react"
+import { useTranslation } from "react-i18next"
+
+export const LanguagePreferenceStep = () => {
+  const { t } = useTranslation("common")
+
+  return (
+    <Stack gap={6} align="center" minH="300px" justify="center">
+      <Text fontSize="2xl" fontWeight="bold" color="ui.main" textAlign="center">
+        {t("onboarding.language.title")}
+      </Text>
+      <LanguagePreference />
+    </Stack>
+  )
+}

--- a/frontend/src/hooks/common/useOnboarding.ts
+++ b/frontend/src/hooks/common/useOnboarding.ts
@@ -10,7 +10,7 @@ import { useAuth } from "../auth"
  * Automatically triggers onboarding for new users who haven't completed it.
  *
  * @returns Object containing onboarding state and control methods
- * @returns {number} returns.currentStep - Current step number (1-4)
+ * @returns {number} returns.currentStep - Current step number (1-5)
  * @returns {boolean} returns.isOpen - Whether onboarding modal is open
  * @returns {boolean} returns.isOnboardingCompleted - Whether user has completed onboarding
  * @returns {function} returns.startOnboarding - Function to start the onboarding process
@@ -40,7 +40,7 @@ import { useAuth } from "../auth"
  * }
  *
  * // Navigate through steps
- * if (currentStep < 4) {
+ * if (currentStep < 5) {
  *   nextStep()
  * }
  *
@@ -84,7 +84,7 @@ export const useOnboarding = () => {
   }
 
   const nextStep = (): void => {
-    if (currentStep < 4) {
+    if (currentStep < 5) {
       setCurrentStep(currentStep + 1)
     }
   }

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -136,6 +136,9 @@
       "tip2": "All content is being referenced with a module",
       "tip3": "Describe any diagrams/images/equations with plain text"
     },
+    "language": {
+      "title": "Choose Your Language"
+    },
     "privacy": {
       "title": "Privacy & Data Usage",
       "description": "Before getting started, please take a moment to review our privacy policy to understand how we handle your data and quiz information.",

--- a/frontend/src/i18n/locales/no/common.json
+++ b/frontend/src/i18n/locales/no/common.json
@@ -136,6 +136,9 @@
       "tip2": "Alt innhold er referert med en modul",
       "tip3": "Beskriv eventuelle diagrammer/bilder/ligninger med ren tekst"
     },
+    "language": {
+      "title": "Velg språk"
+    },
     "privacy": {
       "title": "Personvern og databruk",
       "description": "Før du kommer i gang, ta et øyeblikk til å lese vår personvernerklæring for å forstå hvordan vi håndterer dataene dine og quiz-informasjon.",


### PR DESCRIPTION
## Summary
- Adds language preference selection as step 2 in the onboarding flow
- Users can now choose their preferred UI language (English/Norwegian) during onboarding
- Reuses existing `LanguagePreference` component from user settings

## Test plan
- [ ] Clear localStorage or use new user to trigger onboarding
- [ ] Verify step 2 shows language selection options
- [ ] Verify progress shows "Step X of 5"
- [ ] Verify language selection persists when navigating between steps
- [ ] Verify all 5 steps complete successfully
