### PR TITLE
chore(frontend): remove private deployment-specific content for opensource

### DIFF
--- a/frontend/src/components/Common/QuizTableRow.tsx
+++ b/frontend/src/components/Common/QuizTableRow.tsx
@@ -1,4 +1,4 @@
-import { Badge, HStack, Link, Table, Text, VStack } from "@chakra-ui/react"
+import { Badge, HStack, Table, Text, VStack } from "@chakra-ui/react"
 import { Link as RouterLink } from "@tanstack/react-router"
 import { memo } from "react"
 import { useTranslation } from "react-i18next"
@@ -31,15 +31,7 @@ export const QuizTableRow = memo(function QuizTableRow({
       </Table.Cell>
       <Table.Cell>
         <VStack align="start" gap={1}>
-          <Link
-            href={`https://uit.instructure.com/courses/${quiz.canvas_course_id}`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Text _hover={{ textDecoration: "underline" }}>
-              {quiz.canvas_course_name}
-            </Text>
-          </Link>
+          <Text>{quiz.canvas_course_name}</Text>
           <Text fontSize="sm" color="gray.500">
             {t("quiz:table.modulesSelected", { count: moduleCount })}
           </Text>

--- a/frontend/src/components/Onboarding/steps/SetupStep.tsx
+++ b/frontend/src/components/Onboarding/steps/SetupStep.tsx
@@ -1,30 +1,30 @@
-import { AspectRatio, Box, Stack, Text } from "@chakra-ui/react"
+import { Box, Stack, Text } from "@chakra-ui/react"
 import { useTranslation } from "react-i18next"
 
 export const SetupStep = () => {
   const { t } = useTranslation("common")
 
   return (
-    <Stack gap={6} align="center" minH="300px" justify="center">
-      <Box textAlign="center">
-        <Text fontSize="2xl" fontWeight="bold" color="ui.main" mb={4}>
+    <Stack align="center" minH="300px" justify="center">
+      <Box textAlign="left">
+        <Text
+          fontSize="2xl"
+          fontWeight="bold"
+          color="ui.main"
+          mb={4}
+          textAlign="center"
+        >
           {t("onboarding.setup.title")}
         </Text>
-        <AspectRatio ratio={16 / 9}>
-          <iframe
-            width="560"
-            height="315"
-            src="https://www.youtube.com/embed/E397yownTgs?si=4La3psPHqKLs_ab7"
-            title="YouTube video player"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            referrerPolicy="strict-origin-when-cross-origin"
-            allowFullScreen
-            style={{
-              borderRadius: "8px",
-              border: "none",
-            }}
-          />
-        </AspectRatio>
+        <Text fontSize="lg" color="gray.600" lineHeight="tall">
+          - {t("onboarding.setup.tip1")}
+        </Text>
+        <Text fontSize="lg" color="gray.600" lineHeight="tall">
+          - {t("onboarding.setup.tip2")}
+        </Text>
+        <Text fontSize="lg" color="gray.600" lineHeight="tall">
+          - {t("onboarding.setup.tip3")}
+        </Text>
       </Box>
     </Stack>
   )

--- a/frontend/src/components/Onboarding/steps/WelcomeStep.tsx
+++ b/frontend/src/components/Onboarding/steps/WelcomeStep.tsx
@@ -10,21 +10,9 @@ export const WelcomeStep = () => {
         <Text fontSize="2xl" fontWeight="bold" color="ui.main" mb={4}>
           {t("onboarding.welcome.title")}
         </Text>
-        <Text fontSize="lg" color="gray.600" lineHeight="tall" mb={6}>
+        <Text fontSize="lg" color="gray.600" lineHeight="tall">
           {t("onboarding.welcome.description")}
         </Text>
-        <Box
-          bg="orange.50"
-          border="1px"
-          borderColor="orange.200"
-          borderRadius="md"
-          px={4}
-          py={3}
-        >
-          <Text color="orange.700" fontWeight="medium">
-            ⚠️ {t("onboarding.welcome.developmentWarning")}
-          </Text>
-        </Box>
       </Box>
     </Stack>
   )

--- a/frontend/src/components/QuizCreation/CourseSelectionStep.tsx
+++ b/frontend/src/components/QuizCreation/CourseSelectionStep.tsx
@@ -115,17 +115,6 @@ export function CourseSelectionStep({
         <Text color="gray.600" fontSize="sm">
           {t("courseSelection.chooseDescription")}
         </Text>
-        <Box
-          bg="orange.50"
-          border="1px"
-          borderColor="orange.200"
-          borderRadius="md"
-          px={4}
-          py={3}
-          mt={4}
-        >
-          <Text color="orange.700">{t("courseSelection.devWarning")}</Text>
-        </Box>
       </Box>
 
       <RadioGroup.Root value={selectedCourse?.id?.toString() || ""}>

--- a/frontend/src/components/dashboard/panels/HelpPanel.tsx
+++ b/frontend/src/components/dashboard/panels/HelpPanel.tsx
@@ -96,23 +96,15 @@ export function HelpPanel() {
             </Text>
             <VStack gap={2} align="stretch">
               <Link
-                href="https://uit.instructure.com"
+                href="https://canvas.instructure.com"
                 target="_blank"
                 rel="noopener noreferrer"
                 fontSize="sm"
                 color="blue.600"
                 _hover={{ textDecoration: "underline" }}
               >
-                {t("panels.help.helpfulLinks.canvasUit")}
+                {t("panels.help.helpfulLinks.canvas")}
                 <LuExternalLink />
-              </Link>
-              <Link
-                href="mailto:marius.r.solaas@uit.no"
-                fontSize="sm"
-                color="blue.600"
-                _hover={{ textDecoration: "underline" }}
-              >
-                {t("panels.help.helpfulLinks.contactDeveloper")}
               </Link>
               <Link
                 href="https://github.com/solarmarius/quizcrafter"

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -123,11 +123,13 @@
     "stepProgress": "Step {{current}} of {{total}}",
     "welcome": {
       "title": "Welcome to QuizCrafter",
-      "description": "Thanks for trying us out. Let us show you around and help you get started with everything our application has to offer.",
-      "developmentWarning": "This application is currently in a development phase by IFI-UIT and has not yet been officially released. Please be aware that ongoing support and future development are not guaranteed. Quiz data may be deleted at any time. Features may change or be discontinued at any time."
+      "description": "Thanks for trying us out. Let us show you around and help you get started with everything our application has to offer."
     },
     "setup": {
-      "title": "Walkthrough of the application"
+      "title": "Getting Started",
+      "tip1": "Connect to Canvas and select a course where you are enrolled as a teacher",
+      "tip2": "Choose course modules to include — the more content, the better the questions",
+      "tip3": "Review generated questions and approve or reject them before exporting to Canvas"
     },
     "features": {
       "title": "Prepare your courses",
@@ -156,10 +158,7 @@
   "login": {
     "welcome": "Welcome to QuizCrafter",
     "description": "Turn your Canvas course material into high-quality quizzes with LLMs. Build your question bank, approve with a click, and generate quizzes in minutes.",
-    "errorMessage": "There was an error processing your request: {{error}}",
-    "helpTitle": "Unsure how it works?",
-    "videoTitle": "QuizCrafter demonstration video",
-    "videoDescription": "Watch how QuizCrafter seamlessly integrates with Canvas to analyze your course materials and generate high-quality quizzes."
+    "errorMessage": "There was an error processing your request: {{error}}"
   },
   "navigation": {
     "backToQuestionTypes": "Back to Question Types"

--- a/frontend/src/i18n/locales/en/creation.json
+++ b/frontend/src/i18n/locales/en/creation.json
@@ -17,8 +17,7 @@
     "failedToLoad": "Failed to load courses",
     "selected": "Selected: {{courseName}}",
     "courseId": "Course ID: {{id}}",
-    "unnamedCourse": "Unnamed Course",
-    "devWarning": "During development, only courses with certain prefixes are shown. Contact us if you would like to test with other courses."
+    "unnamedCourse": "Unnamed Course"
   },
   "quizTitle": {
     "label": "Quiz Title",

--- a/frontend/src/i18n/locales/en/dashboard.json
+++ b/frontend/src/i18n/locales/en/dashboard.json
@@ -1,7 +1,6 @@
 {
   "greeting": "Hi, {{name}}",
   "welcome": "Welcome back! Here's an overview of your quizzes and helpful resources.",
-  "developmentWarning": "This application is currently in development phase by IFI-UIT and has not yet been officially released. Please be aware that ongoing support and future development are not guaranteed. Quiz data may be deleted at any time. Features may change or be discontinued at any time.",
   "panels": {
     "generation": {
       "title": "Quizzes Being Generated",
@@ -34,8 +33,7 @@
       },
       "helpfulLinks": {
         "title": "Helpful Links",
-        "canvasUit": "Canvas UiT",
-        "contactDeveloper": "Contact Developer",
+        "canvas": "Canvas",
         "githubRepo": "GitHub Repository",
         "questionTypes": "Question Types Guide"
       },

--- a/frontend/src/i18n/locales/no/common.json
+++ b/frontend/src/i18n/locales/no/common.json
@@ -123,11 +123,13 @@
     "stepProgress": "Steg {{current}} av {{total}}",
     "welcome": {
       "title": "Velkommen til QuizCrafter",
-      "description": "Takk for at du prøver oss. La oss vise deg rundt og hjelpe deg i gang med alt applikasjonen vår har å tilby.",
-      "developmentWarning": "Denne applikasjonen er for øyeblikket i en utviklingsfase av IFI-UIT og er ikke offisielt lansert ennå. Vær oppmerksom på at løpende støtte og fremtidig utvikling ikke er garantert. Quiz-data kan bli slettet når som helst. Funksjoner kan endres eller fjernes når som helst."
+      "description": "Takk for at du prøver oss. La oss vise deg rundt og hjelpe deg i gang med alt applikasjonen vår har å tilby."
     },
     "setup": {
-      "title": "Gjennomgang av applikasjonen"
+      "title": "Kom i gang",
+      "tip1": "Koble til Canvas og velg et emne der du er registrert som lærer",
+      "tip2": "Velg emnemoduler å inkludere — jo mer innhold, desto bedre spørsmål",
+      "tip3": "Gjennomgå genererte spørsmål og godkjenn eller avvis dem før eksport til Canvas"
     },
     "features": {
       "title": "Forbered kursene dine",
@@ -156,10 +158,7 @@
   "login": {
     "welcome": "Velkommen til QuizCrafter",
     "description": "Gjør Canvas-kursmaterialet ditt om til quizer av høy kvalitet med LLM-er. Bygg spørsmålsbanken din, godkjenn med et klikk, og generer quizer på få minutter.",
-    "errorMessage": "Det oppstod en feil under behandling av forespørselen din: {{error}}",
-    "helpTitle": "Usikker på hvordan det fungerer?",
-    "videoTitle": "QuizCrafter demonstrasjonsvideo",
-    "videoDescription": "Se hvordan QuizCrafter sømløst integreres med Canvas for å analysere kursmaterialet ditt og generere quizer av høy kvalitet."
+    "errorMessage": "Det oppstod en feil under behandling av forespørselen din: {{error}}"
   },
   "navigation": {
     "backToQuestionTypes": "Tilbake til spørsmålstyper"

--- a/frontend/src/i18n/locales/no/creation.json
+++ b/frontend/src/i18n/locales/no/creation.json
@@ -17,8 +17,7 @@
     "failedToLoad": "Kunne ikke laste emner",
     "selected": "Valgt: {{courseName}}",
     "courseId": "Emne-ID: {{id}}",
-    "unnamedCourse": "Emne uten navn",
-    "devWarning": "Under utvikling vises bare emner med prefikser 'INF-' og 'MIK-'. Kontakt oss hvis du ønsker å teste med andre emner."
+    "unnamedCourse": "Emne uten navn"
   },
   "quizTitle": {
     "label": "Tittel",

--- a/frontend/src/i18n/locales/no/dashboard.json
+++ b/frontend/src/i18n/locales/no/dashboard.json
@@ -1,7 +1,6 @@
 {
   "greeting": "Hei, {{name}}",
   "welcome": "Velkommen tilbake! Her er en oversikt over quizene dine og nyttige ressurser.",
-  "developmentWarning": "Denne applikasjonen er for tiden i utviklingsfase av IFI-UiT og er ennå ikke offisielt lansert. Vær oppmerksom på at løpende support og fremtidig utvikling ikke er garantert. Quiz-data kan slettes når som helst. Funksjoner kan endres eller avvikles når som helst.",
   "panels": {
     "generation": {
       "title": "Quizer under generering",
@@ -34,8 +33,7 @@
       },
       "helpfulLinks": {
         "title": "Nyttige lenker",
-        "canvasUit": "Canvas UiT",
-        "contactDeveloper": "Kontakt utvikler",
+        "canvas": "Canvas",
         "githubRepo": "GitHub-repository",
         "questionTypes": "Guide til spørsmålstypene vi støtter"
       },

--- a/frontend/src/routes/_layout/index.tsx
+++ b/frontend/src/routes/_layout/index.tsx
@@ -75,20 +75,6 @@ function Dashboard() {
               </RouterLink>
             </Button>
           </HStack>
-          {/* Warning Box */}
-          <Box
-            bg="orange.50"
-            border="1px"
-            borderColor="orange.200"
-            borderRadius="md"
-            px={4}
-            py={3}
-          >
-            <Text color="orange.700" fontWeight="medium">
-              ⚠️ {t("developmentWarning")}
-            </Text>
-          </Box>
-
           {/* Dashboard Panels */}
           <SimpleGrid
             columns={{ base: 1, md: 2, lg: 3 }}

--- a/frontend/src/routes/_layout/privacy-policy-no.tsx
+++ b/frontend/src/routes/_layout/privacy-policy-no.tsx
@@ -34,9 +34,10 @@ function PrivacyPolicyNo() {
           <Heading size="lg" mb={4}>
             1. Introduksjon
           </Heading>
+          {/* TODO: Oppdater organisasjonsnavnet nedenfor for din installasjon */}
           <Text mb={4}>
-            QuizCrafter er en applikasjon utviklet ved UiT Norges arktiske
-            universitet for å hjelpe forelesere og kurskoordinatorer med å
+            QuizCrafter er en applikasjon utviklet ved [Navn på din
+            organisasjon] for å hjelpe forelesere og kurskoordinatorer med å
             generere quizer basert på kursinnhold fra Canvas LMS. Applikasjonen
             forenkler opprettelsen av spørsmålsbanker for quizer og andre
             vurderinger.
@@ -283,9 +284,11 @@ function PrivacyPolicyNo() {
           <Heading size="lg" mb={4}>
             10. Kontaktinformasjon
           </Heading>
+          {/* TODO: Oppdater kontaktnavnet og e-posten nedenfor for din installasjon */}
           <Text>
             Hvis du har spørsmål om denne personvernerklæringen, vennligst
-            kontakt oss på: Marius Solaas, marius.r.solaas@uit.no
+            kontakt oss på: [Navn på behandlingsansvarlig],
+            [kontakt@dittdomene.no]
           </Text>
         </Box>
       </VStack>

--- a/frontend/src/routes/_layout/privacy-policy.tsx
+++ b/frontend/src/routes/_layout/privacy-policy.tsx
@@ -34,12 +34,12 @@ function PrivacyPolicy() {
           <Heading size="lg" mb={4}>
             1. Introduction
           </Heading>
+          {/* TODO: Update the organization name and description below for your deployment */}
           <Text mb={4}>
-            QuizCrafter is an application developed at UiT The Arctic University
-            of Norway to assist instructors and course coordinators in
-            generating quizzes based on course content from Canvas LMS. The
-            application streamlines the creation of question banks for quizzes
-            and exams.
+            QuizCrafter is an application developed at [Your Organization Name]
+            to assist instructors and course coordinators in generating quizzes
+            based on course content from Canvas LMS. The application streamlines
+            the creation of question banks for quizzes and exams.
           </Text>
           <Text mb={4}>
             To continuously improve AI-generated question quality, anonymized
@@ -279,9 +279,10 @@ function PrivacyPolicy() {
           <Heading size="lg" mb={4}>
             7. Contact Information
           </Heading>
+          {/* TODO: Update the contact name and email below for your deployment */}
           <Text>
             If you have any questions about this privacy policy, please contact
-            us at: Marius Solaas, marius.r.solaas@uit.no
+            us at: [Data Controller Name], [contact@yourdomain.com]
           </Text>
         </Box>
       </VStack>

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -1,12 +1,4 @@
-import {
-  Alert,
-  AspectRatio,
-  Box,
-  Container,
-  Image,
-  Text,
-  VStack,
-} from "@chakra-ui/react"
+import { Alert, Container, Image, Text, VStack } from "@chakra-ui/react"
 import { createFileRoute, redirect } from "@tanstack/react-router"
 import { useTranslation } from "react-i18next"
 
@@ -68,31 +60,6 @@ function Login() {
 
         {/* Canvas Login */}
         <CanvasLoginButton />
-
-        {/* Help Section */}
-        <Box bg="gray.50" p={4} borderRadius="md" width="100%" mt={4}>
-          <Text fontSize="sm" fontWeight="medium" mb={3}>
-            {t("login.helpTitle")}
-          </Text>
-          <AspectRatio ratio={16 / 9} mb={3}>
-            <iframe
-              width="560"
-              height="315"
-              src="https://www.youtube.com/embed/zV6bP3IMZ9w?si=9L1scxQGRYqMuCP-"
-              title={t("login.videoTitle")}
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-              referrerPolicy="strict-origin-when-cross-origin"
-              allowFullScreen
-              style={{
-                borderRadius: "8px",
-                border: "none",
-              }}
-            />
-          </AspectRatio>
-          <Text fontSize="xs" color="gray.600">
-            {t("login.videoDescription")}
-          </Text>
-        </Box>
       </VStack>
     </Container>
   )


### PR DESCRIPTION
- Remove YouTube video sections from login page and onboarding SetupStep; replace SetupStep with generic "Getting Started" tips
- Remove all IFI-UIT development warning banners (dashboard, onboarding WelcomeStep, course selection step)
- Replace hardcoded UiT Canvas link with generic canvas.instructure.com; remove personal Contact Developer mailto link from HelpPanel
- Remove hardcoded uit.instructure.com course link from QuizTableRow
- Replace UiT/personal contact details in privacy policy pages with configurable placeholders and TODO comments